### PR TITLE
defect fix: set jwt properly when registering

### DIFF
--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -133,15 +133,15 @@ const userModule: Module<State, RootState> = {
 
     async register({ commit, state, rootState }, { name, password, seed }) {
       if (!state.registered) {
-        const jwt = await rootState.citadel.manager.auth.register(
+        const { jwt } = await rootState.citadel.manager.auth.register(
           name,
           password,
           seed
         );
 
-        if (jwt.jwt) {
-          commit("setJwt", jwt.jwt);
-          commit("setJwt", jwt.jwt, { root: true });
+        if (jwt) {
+          commit("setJwt", jwt);
+          commit("setJwt", jwt, { root: true });
           commit("setRegistered", true);
           commit("setSeed", []); //remove seed from store
         }

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -139,9 +139,9 @@ const userModule: Module<State, RootState> = {
           seed
         );
 
-        if (jwt) {
-          commit("setJwt", jwt);
-          commit("setJwt", jwt, { root: true });
+        if (jwt.jwt) {
+          commit("setJwt", jwt.jwt);
+          commit("setJwt", jwt.jwt, { root: true });
           commit("setRegistered", true);
           commit("setSeed", []); //remove seed from store
         }


### PR DESCRIPTION
rootState.citadel.manager.auth.register() returns an object with a property named "jwt". The object was being set as the jwt in the store, but the store's state was expecting a string. I made a couple minor changes only in the register action where the jwt string is now extracted from the object returned by the manager API.