### PR TITLE
Fix: too many pings to manager after reboot

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -108,7 +108,7 @@ export default defineComponent({
     };
   },
   computed: {
-    updating() {
+    updating(): boolean {
       return this.systemStore.updateStatus.state === 'installing';
     },
   },

--- a/src/store/system.ts
+++ b/src/store/system.ts
@@ -264,7 +264,9 @@ export default defineStore('system', {
           // System is online again
           this.rebooting = false;
           this.hasRebooted = true;
-          return window.clearInterval(pollIfUp);
+
+          // user has to re-login
+          window.location.reload();
         }
       };
       // Poll to check if system has shut down
@@ -280,7 +282,13 @@ export default defineStore('system', {
             return;
           }
         } catch {
+          // System shut down successfully
+          window.clearInterval(pollIfDown);
+          window.clearInterval(pollIfUp);
+
+          // Now we'll poll to check if it's up
           pollIfUp = window.setInterval(pollIfUpFunction, 2000);
+          return;
         }
       }, 2000);
     },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -860,7 +860,6 @@ export default defineComponent({
       // Shutdown request
       try {
         await this.systemStore.shutdown();
-        this.toast.success('Shutdown successful');
       } catch (error) {
         console.error(error);
         this.toast.error(


### PR DESCRIPTION
- clear some intervals that were causing way too many requests on reboot
- refresh the page for the user, had to manually refresh the page because of invalid JWT
- removes the success toast for shutdown, there's already a nice screen for that