### PR TITLE
Fix: Retry app checks with CORS

### DIFF
--- a/src/components/InstalledApp.vue
+++ b/src/components/InstalledApp.vue
@@ -168,8 +168,15 @@ export default defineComponent({
           await window.fetch(this.url, {mode: 'no-cors'});
           this.isOffline = false;
           this.checkIfAppIsOffline = false;
-        } catch (error) {
-          this.isOffline = true;
+        } catch {
+          await delay(1000);
+          try {
+            await window.fetch(this.url);
+            this.isOffline = false;
+            this.checkIfAppIsOffline = false;
+          } catch {
+            this.isOffline = true;
+          }
         }
         await delay(1000);
       }


### PR DESCRIPTION
This fix was originally created for ringtools, which has no CORS protection, but CORP https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP) which causes no-cors requests to fail.

However, it should also help for some other apps in the future.
