### PR TITLE
Skip app check for ringtools

### DIFF
--- a/src/components/InstalledApp.vue
+++ b/src/components/InstalledApp.vue
@@ -46,6 +46,8 @@ import {TrashIcon} from '@bitcoin-design/bitcoin-icons-vue/filled/esm/index.js';
 
 import delay from '../helpers/delay';
 
+const skipCheckApps = ['bluewallet', 'ringtools'];
+
 export default defineComponent({
   components: {
     TrashIcon,
@@ -162,7 +164,7 @@ export default defineComponent({
     },
     async pollOfflineApp() {
       this.checkIfAppIsOffline = true;
-      if (this.id === 'bluewallet') this.checkIfAppIsOffline = false;
+      if (skipCheckApps.includes(this.id)) this.checkIfAppIsOffline = false;
       while (this.checkIfAppIsOffline) {
         try {
           await window.fetch(this.url, {mode: 'no-cors'});

--- a/src/views/AppStoreApp.vue
+++ b/src/views/AppStoreApp.vue
@@ -435,8 +435,10 @@ function openApp(event: Event) {
   }
   return;
 }
+const skipCheckApps = ['bluewallet', 'ringtools'];
 async function pollOfflineApp() {
   checkIfAppIsOffline.value = true;
+  if (skipCheckApps.includes(app.value.id)) checkIfAppIsOffline.value = false;
   while (checkIfAppIsOffline.value) {
     try {
       await window.fetch(url.value, {mode: 'no-cors'});


### PR DESCRIPTION
Even with the CORS fix, the app was still shown as "starting". So this will work as a temporary workaround for 0.0.5