### PR TITLE
fix: update version update alert styles

### DIFF
--- a/src/layouts/DashboardLayout.vue
+++ b/src/layouts/DashboardLayout.vue
@@ -153,32 +153,34 @@
         </b-modal>
         <div class="pe-xl-2 content-container">
           <b-alert
+            :show="!!systemStore.availableUpdate.version"
             class="mt-4 mb-0"
             variant="success"
-            :show="!!systemStore.availableUpdate.version"
-            dismissible
           >
-            <div class="icon-16px"><BellIcon /></div>
-            <a
-              :href="`https://github.com/runcitadel/core/releases/tag/v${systemStore.availableUpdate.version}`"
-              target="_blank"
-              class="alert-link"
-              >{{ systemStore.availableUpdate.name }}</a
-            >
-            &nbsp;is now available to install
-            <a
-              v-show="!isUpdating"
-              href="#"
-              class="alert-link float-right"
-              @click.prevent="confirmUpdate"
-              >Install now</a
-            >
-            <b-spinner
-              v-show="isUpdating"
-              variant="success"
-              small
-              class="float-right mt-1"
-            ></b-spinner>
+            <div class="d-flex align-items-center mb-0">
+              <div class="icon-24px"><BellIcon /></div>
+              <a
+                :href="`https://github.com/runcitadel/core/releases/tag/v${systemStore.availableUpdate.version}`"
+                target="_blank"
+                class="alert-link"
+                >{{ systemStore.availableUpdate.name }}</a
+              >
+              &nbsp;is now available to install.
+            </div>
+            <div class="mt-2">
+              <b-button
+                v-show="!isUpdating"
+                variant="primary"
+                size="sm"
+                :disabled="isUpdating"
+                @click.prevent="confirmUpdate"
+                >Install now</b-button
+              >
+              <div v-if="isUpdating" class="d-flex align-items-center">
+                <b-spinner class="me-1" variant="success" small></b-spinner>
+                Installing...
+              </div>
+            </div>
           </b-alert>
           <b-alert
             v-if="isRunningLowOnRam"

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -513,21 +513,23 @@
               >
             </span>
             <div v-show="systemStore.availableUpdate.version">
-              <span class="d-block">
-                <div class="icon-16px"><BellIcon /></div>
+              <span class="d-flex align-items-center">
+                <div class="d-flex align-items-center icon-16px">
+                  <BellIcon />
+                </div>
                 <small class="text-muted ms-1"
                   >{{ systemStore.availableUpdate.name }} is now available to
                   install</small
                 >
+                <b-button
+                  class="ms-auto"
+                  variant="primary"
+                  size="sm"
+                  :disabled="isUpdating"
+                  @click.prevent="confirmUpdate"
+                  >Install now</b-button
+                >
               </span>
-              <b-button
-                class="mt-2"
-                variant="primary"
-                size="sm"
-                :disabled="isUpdating"
-                @click.prevent="confirmUpdate"
-                >Install now</b-button
-              >
             </div>
           </div>
         </div>


### PR DESCRIPTION
Some small design cleanups around the version update notifications. Still not pretty but better than before.

Before:
![Screenshot_20220607_161752](https://user-images.githubusercontent.com/8538369/172410080-bbc626e2-e47a-42a9-8040-7a39d4fc5a70.png)

After:
![Screenshot_20220607_164041](https://user-images.githubusercontent.com/8538369/172410084-d9037e8a-e509-4b7d-b679-cb2c9c9a4e9e.png)

Before:
![Screenshot_20220607_164356](https://user-images.githubusercontent.com/8538369/172410089-a2fcc8fe-e1d7-4913-8f4f-8ce96f8fa225.png)

After:
![Screenshot_20220607_164340](https://user-images.githubusercontent.com/8538369/172410086-31202b2f-73b7-4996-880c-afb106942ef1.png)
