### PR TITLE
Add search feature to the app store

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "buffer": "^6.0.3",
     "countup.js": "^2.1.0",
     "date-fns": "^2.28.0",
+    "fuse.js": "^6.6.2",
     "pinia": "^2.0.11",
     "qrcode.vue": "^3.3.3",
     "typescript": "^4.6.2",

--- a/src/views/AppStore.vue
+++ b/src/views/AppStore.vue
@@ -8,6 +8,14 @@
         </p>
       </div>
     </div>
+    <b-input
+      v-model="searchQuery"
+      class="neu-input"
+      placeholder="Search for apps"
+      type="text"
+      size="lg"
+      autofocus
+    ></b-input>
     <div class="app-store-card-columns card-columns">
       <card-widget
         v-for="categorizedApps in categorizedAppStore"
@@ -89,18 +97,35 @@
 <script lang="ts" setup>
 import {computed, ref} from 'vue';
 import useAppsStore, {app as appType} from '../store/apps';
+import Fuse from 'fuse.js';
 
 import CardWidget from '../components/CardWidget.vue';
 
 const appsStore = useAppsStore();
 
 const showIncompatible = ref(false);
+const searchQuery = ref('');
+
 const compatibleApps = computed(() => {
   return appsStore.store.filter((app) => app.compatible);
 });
 
+const appsToShow = computed(() => {
+  return showIncompatible.value ? appsStore.store : compatibleApps.value;
+});
+
+const fuse = computed(() => {
+  return new Fuse(appsToShow.value, {keys: ['name', 'tagline']});
+});
+
+const foundApps = computed(() => {
+  if (!searchQuery.value) return appsToShow.value;
+  let result = fuse.value.search(searchQuery.value).map((val) => val.item);
+  return result ? result : appsToShow.value;
+});
+
 const categorizedAppStore = computed((): Record<string, appType[]> => {
-  let store = showIncompatible.value ? appsStore.store : compatibleApps.value;
+  let store = foundApps.value as appType[];
   let group = store.reduce((r: Record<string, appType[]>, app) => {
     r[app.category] = [...(r[app.category] || []), app];
     return r;

--- a/src/views/AppStore.vue
+++ b/src/views/AppStore.vue
@@ -10,7 +10,7 @@
     </div>
     <b-input
       v-model="searchQuery"
-      class="neu-input"
+      class="neu-input my-4"
       placeholder="Search for apps"
       type="text"
       size="lg"

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,6 +175,7 @@ __metadata:
     eslint-config-prettier: ^8.5.0
     eslint-plugin-prettier: ^4.0.0
     eslint-plugin-vue: ^8.5.0
+    fuse.js: ^6.6.2
     husky: ^7.0.0
     pinia: ^2.0.11
     prettier: ^2.5.1
@@ -1506,6 +1507,13 @@ __metadata:
   version: 1.0.1
   resolution: "functional-red-black-tree@npm:1.0.1"
   checksum: ca6c170f37640e2d94297da8bb4bf27a1d12bea3e00e6a3e007fd7aa32e37e000f5772acf941b4e4f3cf1c95c3752033d0c509af157ad8f526e7f00723b9eb9f
+  languageName: node
+  linkType: hard
+
+"fuse.js@npm:^6.6.2":
+  version: 6.6.2
+  resolution: "fuse.js@npm:6.6.2"
+  checksum: 17ae758ce205276ebd88bd9c9f088a100be0b4896abac9f6b09847151269d1690f41d7f98ff5813d4a58973162dbd99d0072ce807020fee6f9de60170f6b08eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As the app store grows, a search feature should make using it much easier. This uses fuse.js, so it doesn't search for exact matches, but allows for small differences.

![image](https://user-images.githubusercontent.com/67546953/172544784-7f2612e2-9b39-40a8-babc-e32dfcf3e960.png)

![image](https://user-images.githubusercontent.com/67546953/172544873-74a644d1-8b2d-4c8b-a3ee-31ad191a1021.png)

