### PR TITLE
fix: CSS columns causing jank in some OS/browsers

### DIFF
--- a/src/global-styles/responsive.scss
+++ b/src/global-styles/responsive.scss
@@ -7,13 +7,41 @@
 
 .card-columns {
   column-count: 1;
+  column-gap: 30px;
+
   @include media-breakpoint-up(md) {
     column-count: 2;
   }
+
   @media (min-width: 1600px) {
     column-count: 3;
   }
+}
+
+.settings-card-columns {
+  column-count: 1;
   column-gap: 30px;
+
+  @include media-breakpoint-up(md) {
+    column-count: 2;
+  }
+
+  @media (min-width: 1600px) {
+    column-count: unset;
+    column-gap: unset;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    max-height: 1200px;
+
+    .card {
+      min-width: 400px;
+
+      &:not(:last-child) {
+        margin-right: 30px;
+      }
+    }
+  }
 }
 
 .app-name {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -6,7 +6,7 @@
       </div>
     </div>
 
-    <div class="settings-card-columns card-columns">
+    <div class="settings-card-columns">
       <storage-widget id="storage" class="card-app-list"></storage-widget>
 
       <ram-widget id="ram" class="card-app-list"></ram-widget>
@@ -518,8 +518,8 @@
                   <BellIcon />
                 </div>
                 <small class="text-muted ms-1"
-                  >{{ systemStore.availableUpdate.name }} is now available to
-                  install</small
+                  >{{ systemStore.availableUpdate.name }} is now
+                  available</small
                 >
                 <b-button
                   class="ms-auto"


### PR DESCRIPTION
Moved to Flexbox on desktop for the columns on the Settings screen. Smaller viewports still use the columns, but I would consider that an edge case. Plus a small wording change to avoid breaking text.

https://user-images.githubusercontent.com/8538369/175564473-5394ad47-e108-41b4-a073-8a18736a2f66.MOV

