### PR TITLE
Recommend LNDHub.go instead of LNDHub

### DIFF
--- a/src/components/ConnectWallet/Wallets/BlueWallet.vue
+++ b/src/components/ConnectWallet/Wallets/BlueWallet.vue
@@ -3,8 +3,7 @@
     <step-list>
       <step>
         Install the
-        <b-link to="/app-store/bluewallet">BlueWallet Lightning</b-link> app on
-        your Citadel.
+        <b-link to="/app-store/lndhub">LNDHub</b-link> app on your Citadel.
       </step>
       <step>
         Open BlueWallet on your phone, tap the three dots to access the settings
@@ -16,8 +15,7 @@
       </step>
       <step>
         Scan the QR code displayed in the
-        <b-link to="/app-store/bluewallet">BlueWallet Lightning</b-link> app on
-        your Citadel.
+        <b-link to="/app-store/lndhub">LNDHub</b-link> app on your Citadel.
       </step>
       <step> Tap <span class="font-weight-bold">"Save"</span>. </step>
       <step>


### PR DESCRIPTION
This recommends the new "LNDHub" app over "BlueWallet Server"

BlueWallet Srver was the original LNDHub, LNDHub.go is a API-compatible extended rewrite in Go with a Postgres DB.

This database will make extending LNDHub.go much easier, and LNDHub.go is also actively updated and has more API endpoints.

LNDHub.go is only available in the quick-updates branch of core.